### PR TITLE
switch back to merk(for open source)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 ruc = { git = "https://github.com/FindoraNetwork/RUC.git", branch = "master" }
-merk = { git = "https://github.com/FindoraNetwork/merkle", branch = "findora" }
+merk = { git = "https://github.com/FindoraNetwork/merk", branch = "findora" }
 rocksdb = "0.17.0"
 parking_lot = "0.11.1"
 serde = "1.0.124"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 ruc = { git = "https://github.com/FindoraNetwork/RUC.git", branch = "master" }
-merk = { git = "https://github.com/FindoraNetwork/merk", branch = "findora" }
+merk = { git = "https://github.com/FindoraNetwork/fmerk.git", branch = "master" }
 rocksdb = "0.17.0"
 parking_lot = "0.11.1"
 serde = "1.0.124"


### PR DESCRIPTION
1. points back to merk because merkle is temp repo