### PR TITLE
Merkle flag

### DIFF
--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -26,20 +26,22 @@ impl<'a> Iterator for CacheIter<'a> {
 pub struct SessionedCache {
     cur: KVMap,
     base: KVMap,
+    is_merkle: bool,
 }
 
 #[allow(clippy::new_without_default)]
 impl SessionedCache {
-    pub fn new() -> Self {
+    pub fn new(is_merkle: bool) -> Self {
         SessionedCache {
             cur: KVMap::new(),
             base: KVMap::new(),
+            is_merkle,
         }
     }
 
     /// put/update value by key
     pub fn put(&mut self, key: &[u8], value: Vec<u8>) -> bool {
-        if MerkChecker::check_kv(key, &value) {
+        if Self::check_kv(key, &value, self.is_merkle) {
             self.cur.insert(key.to_owned(), Some(value));
             return true;
         }
@@ -83,6 +85,11 @@ impl SessionedCache {
     /// use case: when KV is not allowed to updated twice
     pub fn touched(&self, key: &[u8]) -> bool {
         self.cur.contains_key(key)
+    }
+
+    /// Returns whether the cache is used for MerkDB or RocksDB
+    pub fn is_merkle(&self) -> bool {
+        self.is_merkle
     }
 
     /// KV deleted or not
@@ -184,6 +191,16 @@ impl SessionedCache {
     fn rebase(&mut self) {
         self.base = self.cur.clone();
     }
+
+    /// checks key value ranges
+    ///
+    /// if this cache is built on a MerkDB then ranges are enforced otherwise ranges are ignored.
+    fn check_kv(key: &[u8], value: &[u8], is_merkle: bool) -> bool {
+        if is_merkle {
+            return MerkChecker::check_kv(key, value);
+        }
+        NoneChecker::check_kv(key, value)
+    }
 }
 
 /// KV checker
@@ -224,7 +241,7 @@ mod tests {
 
     #[test]
     fn cache_put_n_get() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
 
         // put data
         cache.put(b"k10", b"v10".to_vec());
@@ -256,7 +273,7 @@ mod tests {
 
     #[test]
     fn cache_put_n_update() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
 
         // put data
         cache.put(b"k10", b"v10".to_vec());
@@ -292,7 +309,7 @@ mod tests {
 
     #[test]
     fn cache_put_n_delete() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
 
         // put data
         cache.put(b"k10", b"v10".to_vec());
@@ -328,7 +345,7 @@ mod tests {
 
     #[test]
     fn cache_put_n_commit() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
 
         // put data and commit
         cache.put(b"k10", b"v10".to_vec());
@@ -361,7 +378,7 @@ mod tests {
 
     #[test]
     fn cache_commit_n_put_delete_again() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
 
         // put data and commit
         cache.put(b"k10", b"v10".to_vec());
@@ -419,7 +436,7 @@ mod tests {
 
     #[test]
     fn cache_commit_n_put_delete_n_discard() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
 
         // put data and commit
         cache.put(b"k10", b"v10".to_vec());
@@ -471,7 +488,7 @@ mod tests {
 
     #[test]
     fn cache_put_n_iterate() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
 
         // put data in random order
         cache.put(b"k10", b"v10".to_vec());
@@ -492,7 +509,7 @@ mod tests {
 
     #[test]
     fn cache_put_delete_n_iterate() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
 
         // put data in random order
         cache.put(b"k10", b"v10".to_vec());
@@ -520,7 +537,7 @@ mod tests {
 
     #[test]
     fn cache_commit_n_put_delete_discard_n_iterate() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
 
         // put data in random order and delete one
         cache.put(b"k10", b"v10".to_vec());
@@ -564,7 +581,7 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
 
         //Put some date into cache
         cache.put(b"k40", b"v40".to_vec());
@@ -592,7 +609,7 @@ mod tests {
 
     #[test]
     fn test_iterate_prefix() {
-        let mut cache = SessionedCache::new();
+        let mut cache = SessionedCache::new(true);
         let mut my_cache = KVecMap::new();
 
         //Put some date into cache

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -225,9 +225,7 @@ impl KVChecker for MerkChecker {
 
         // check value
         if value.len() > MAX_MERK_VAL_LEN as usize {
-            let val_str =
-                String::from_utf8(value.to_vec()).map_or("non-utf8-value".to_owned(), |v| v);
-            println!("Invalid value length: {}", val_str);
+            println!("Invalid value length: {}", value.len());
             return false;
         }
         true

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -404,6 +404,29 @@ mod tests {
         state.commit(1).unwrap();
     }
 
+    #[test]
+     fn test_rocksdb_set_big_key_unchecked() {
+        // Setup
+        let path = thread::current().name().unwrap().to_owned();
+        let cs = gen_cs_rocks(path);
+
+        // Make sure is_merkle flag is false
+        let mut state = State::new(cs, false);
+
+        // Set maximum valid key and value
+        let max_key = "k".repeat(u8::MAX as usize).as_bytes().to_vec();
+        let max_val = "v".repeat(u16::MAX as usize).as_bytes().to_vec();
+        state.set(&max_key, max_val.clone()).unwrap();
+        assert_eq!(state.get(&max_key).unwrap(), Some(max_val));
+
+        // Set a big key
+        let big_key = "k".repeat(u8::MAX as usize + 1).as_bytes().to_vec();
+        assert!(state.set(&big_key, b"v10".to_vec()).is_ok());
+
+        // Panic on commit
+        state.commit(1).unwrap();
+    }
+
     fn test_delete_impl<D: MerkleDB>(cs: Arc<RwLock<ChainState<D>>>) {
         //Setup
         let mut state = State::new(cs, true);

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -178,7 +178,7 @@ mod tests {
             "test_db".to_string(),
             VER_WINDOW,
         )));
-        let mut state = State::new(cs);
+        let mut state = State::new(cs, true);
         let mut store = PrefixedStore::new("my_store", &mut state);
         let hash0 = store.state().root_hash();
 
@@ -219,7 +219,7 @@ mod tests {
             "findora_db".to_string(),
             VER_WINDOW,
         )));
-        let mut check = State::new(cs);
+        let mut check = State::new(cs, true);
         let mut store = StakeStore::new("stake", &mut check);
 
         // default stake MUST be zero
@@ -264,7 +264,7 @@ mod tests {
             "findora_db".to_string(),
             VER_WINDOW,
         )));
-        let mut check = State::new(cs);
+        let mut check = State::new(cs, true);
         let mut store = StakeStore::new("stake", &mut check);
 
         // stake some coins
@@ -298,7 +298,7 @@ mod tests {
             "findora_db".to_string(),
             VER_WINDOW,
         )));
-        let mut check = State::new(cs);
+        let mut check = State::new(cs, true);
         let mut store = StakeStore::new("stake", &mut check);
 
         // stake some coins at height 1
@@ -343,7 +343,7 @@ mod tests {
             "findora_db".to_string(),
             VER_WINDOW,
         )));
-        let mut check = State::new(cs);
+        let mut check = State::new(cs, true);
         let mut store = StakeStore::new("stake", &mut check);
 
         // stake some coins
@@ -411,7 +411,7 @@ mod tests {
             "findora_db".to_string(),
             VER_WINDOW,
         )));
-        let mut check = State::new(cs);
+        let mut check = State::new(cs, true);
         let mut store = StakeStore::new("stake", &mut check);
 
         // stake some coins and commit block 1
@@ -456,7 +456,7 @@ mod tests {
             "findora_db".to_string(),
             VER_WINDOW,
         )));
-        let mut state = State::new(cs.clone());
+        let mut state = State::new(cs.clone(), true);
         let mut store = StakeStore::new("stake", &mut state);
 
         // stake initial coins and commit
@@ -482,7 +482,7 @@ mod tests {
         let cs_1 = cs.clone();
         threads.push(thread::spawn(move || {
             // create store
-            let mut query = State::new(cs_1.clone());
+            let mut query = State::new(cs_1.clone(), true);
             let store = StakeStore::new("stake", &mut query);
 
             // starts
@@ -507,7 +507,7 @@ mod tests {
         let cs_2 = cs.clone();
         threads.push(thread::spawn(move || {
             // create store
-            let mut query = State::new(cs_2.clone());
+            let mut query = State::new(cs_2.clone(), true);
             let store = StakeStore::new("stake", &mut query);
 
             let mut reads = 0;
@@ -535,7 +535,7 @@ mod tests {
         let cs_3 = cs.clone();
         threads.push(thread::spawn(move || {
             // create store
-            let mut check = State::new(cs_3.clone());
+            let mut check = State::new(cs_3.clone(), true);
             let store = StakeStore::new("stake", &mut check);
 
             let mut reads = 0;
@@ -563,7 +563,7 @@ mod tests {
         let cs_4 = cs;
         threads.push(thread::spawn(move || {
             // create store
-            let mut deliver = State::new(cs_4.clone());
+            let mut deliver = State::new(cs_4.clone(), true);
             let mut store = StakeStore::new("stake", &mut deliver);
 
             // starts
@@ -622,7 +622,7 @@ mod tests {
             "findora_db".to_string(),
             VER_WINDOW,
         )));
-        let mut state = State::new(cs);
+        let mut state = State::new(cs, true);
         let mut store = PrefixedStore::new("testStore", &mut state);
 
         store.set(b"validator_fra2221", b"200".to_vec()).unwrap();


### PR DESCRIPTION
Added a flag to determine whether the backend uses RocksDB or MerkDB

* The range checks on the key and values will be ignored for RocksDB and enforced for MerkDB