### PR TITLE
Block versioned query on keys that don't exist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage"
-version = "0.1.0"
+version = "0.1.2"
 authors = ["FindoraNetwork"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,8 @@ version = "0.1.0"
 authors = ["FindoraNetwork"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-ruc = { git = "https://github.com/FindoraNetwork/RUC.git", branch = "master" }
+ruc = "0.6.2"
 fmerk = "0.1.1"
 parking_lot = "0.11.1"
 serde = "1.0.124"

--- a/src/db/rocks_db.rs
+++ b/src/db/rocks_db.rs
@@ -64,6 +64,10 @@ impl RocksDB {
         let state_cf = self.db.cf_handle(CF_STATE).unwrap();
         self.db.iterator_cf_opt(state_cf, readopts, mode)
     }
+    
+    pub fn clone(&self) -> Self {
+        RocksDB::open(self.path.clone()).unwrap()
+    }
 }
 
 impl MerkleDB for RocksDB {

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -23,6 +23,7 @@ impl<'a> Iterator for CacheIter<'a> {
 }
 
 /// sessioned KV cache
+#[derive(Clone)]
 pub struct SessionedCache {
     cur: KVMap,
     base: KVMap,

--- a/src/state/chain_state.rs
+++ b/src/state/chain_state.rs
@@ -416,11 +416,16 @@ impl<D: MerkleDB> ChainState<D> {
     /// Returns the value of the given key at a particular height
     /// Returns None if the key was deleted or invalid at height H
     pub fn get_ver(&self, key: &[u8], height: u64) -> Result<Option<Vec<u8>>> {
+        //Make sure that this key exists to avoid expensive query
+        if self.get(key).c(d!("error getting value"))?.is_none() {
+            return Ok(None);
+        }
+
         //Need to set lower and upper bound as the height can get very large
         let mut lower_bound = 1;
         let upper_bound = height;
         let cur_height = self.height().c(d!("error reading current height"))?;
-        if height > cur_height {
+        if height >= cur_height {
             return self.get(key);
         }
         if cur_height > self.ver_window {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 ///
 /// Contains a Reference to the ChainState and a Session Cache used for collecting batch data
 /// and transaction simulation.
+#[derive(Clone)]
 pub struct State<D: MerkleDB> {
     chain_state: Arc<RwLock<ChainState<D>>>,
     cache: SessionedCache,


### PR DESCRIPTION
1. Block versioned query on keys that don't exist. Those query can potentially be a search on the whole database.