### PR TITLE
Simplified delete/remove logic and fixed more edge cases

### DIFF
--- a/fin_db/src/lib.rs
+++ b/fin_db/src/lib.rs
@@ -1,4 +1,4 @@
-use fmerk::{rocksdb, tree::Tree, Merk, Op, BatchEntry};
+use fmerk::{rocksdb, tree::Tree, BatchEntry, Merk, Op};
 use ruc::*;
 use std::path::{Path, PathBuf};
 use storage::db::{IterOrder, KVBatch, KValue, MerkleDB};


### PR DESCRIPTION
1. Removed `remove()` from cache and leave one single interface `delete()` to make it straightforward.
2. Adjusted test cases accordingly.