### PR TITLE
Prepare a version of `storage` with Ruc 3.0.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "*" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/fin_db/Cargo.toml
+++ b/fin_db/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["FindoraNetwork"]
 edition = "2021"
 
 [dependencies]
-ruc = "1.0"
+ruc = "3.0.0"
 fmerk = { git = "https://github.com/FindoraNetwork/fmerk.git", branch = "trace_option"}
 storage = { path = "../storage", version = "0.2" }
 

--- a/mem_db/Cargo.toml
+++ b/mem_db/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 bincode = "1.3"
-ruc = "1.0"
+ruc = "3.0.0"
 serde = { version = "1.0", features = ["derive"] }
 storage = { path = "../storage", version = "0.2" }
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 parking_lot = "0.12"
 rand = "0.8"
-ruc = "1.0"
+ruc = "3.0.0"
 serde = "1.0"
 serde_json = "1.0"
 

--- a/temp_db/Cargo.toml
+++ b/temp_db/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["FindoraNetwork"]
 edition = "2021"
 
 [dependencies]
-ruc = "1.0"
+ruc = "3.0.0"
 fmerk = { git = "https://github.com/FindoraNetwork/fmerk.git", branch = "trace_option"}
 storage = { path = "../storage", version = "0.2" }
 fin_db = { path = "../fin_db", version = "0.2" }


### PR DESCRIPTION
Ruc is a collection of Rust utils. We have been using it for error handling, with version 1.0.

This PR prepares the `storage` to Ruc 3.0.0. A release would be cut. 